### PR TITLE
Replace &nbsp; with space rather than blank

### DIFF
--- a/lib/html_to_plain_text.rb
+++ b/lib/html_to_plain_text.rb
@@ -73,19 +73,19 @@ module HtmlToPlainText
 
       parent.children.each do |node|
         if node.text? || node.cdata?
-          text = node.text.gsub(NON_BREAKING_SPACE, EMPTY)
+          text = node.text.gsub(NON_BREAKING_SPACE, SPACE)
           text = text.gsub(/#{LEFT_SINGLE_QUOTE}|#{RIGHT_SINGLE_QUOTE}/, APOSTROPHE)
           text = text.gsub(/#{LEFT_DOUBLE_QUOTE}|#{RIGHT_DOUBLE_QUOTE}/, QUOTE)
           unless options[:pre]
             text = node.text.gsub(LINE_BREAK_PATTERN, SPACE).squeeze(SPACE)
-            text = text.gsub(NON_BREAKING_SPACE, EMPTY)
+            text = text.gsub(NON_BREAKING_SPACE, SPACE)
             text = text.gsub(/#{LEFT_SINGLE_QUOTE}|#{RIGHT_SINGLE_QUOTE}/, APOSTROPHE)
             text = text.gsub(/#{LEFT_DOUBLE_QUOTE}|#{RIGHT_DOUBLE_QUOTE}/, QUOTE)
             text.lstrip! if WHITESPACE.include?(out[-1, 1])
           end
           out << text
         elsif node.name == PLAINTEXT
-          text = node.text.gsub(NON_BREAKING_SPACE, EMPTY)
+          text = node.text.gsub(NON_BREAKING_SPACE, SPACE)
           text = text.gsub(/#{LEFT_SINGLE_QUOTE}|#{RIGHT_SINGLE_QUOTE}/, APOSTROPHE)
           text = text.gsub(/#{LEFT_DOUBLE_QUOTE}|#{RIGHT_DOUBLE_QUOTE}/, QUOTE)
           out << text

--- a/spec/html_to_plain_text_spec.rb
+++ b/spec/html_to_plain_text_spec.rb
@@ -154,4 +154,15 @@ RSpec.describe HtmlToPlainText do
     expect(text(html)).to eq "I sometimes use fancy quotes like ' ' \" and \""
   end
 
+  it 'handles non-breaking space' do
+    html = '<p>I sometimes&nbsp;use funny spaces</p>'
+    expect(text(html)).to eq "I sometimes use funny spaces"
+    html = '<p>I sometimes&nbsp;&nbsp;&nbsp;use funny spaces</p>'
+    expect(text(html)).to eq "I sometimes   use funny spaces"
+    html = '<p>Start<span>&nbsp;</span>End</span>'
+    expect(text(html)).to eq "Start End"
+    html = '<p><pre>I sometimes&nbsp;use funny spaces</pre></p>'
+    expect(text(html)).to eq "I sometimes use funny spaces"
+  end
+
 end


### PR DESCRIPTION
In #1 we replaced `&nbsp;` with blank, but this causes unexpected behavior with a lot of input. Instead generate a space.